### PR TITLE
Update to RGMercs Lua & Turn burns off function

### DIFF
--- a/MQ2Boxr.cpp
+++ b/MQ2Boxr.cpp
@@ -41,6 +41,8 @@ void printUsage() {
 		"\a-t|\ax  \ay/boxr Camp\ax - Sets navigation to camp at current position, and return to camp after combat\n"
 		"\a-t|\ax  \ay/boxr Manual\ax - Sets manual navigation (don't chase, no camp)\n"
 		"\a-t|\ax  \ay/boxr BurnNow\ax - Burn current target\n"
+		"\a-t|\ax  \ay/boxr BurnOff\ax - Turn Burns Off\n"
+		"\a-t|\ax  \ay/boxr BurnNamed\ax - Burn Named targets\n"
 #if !defined(ROF2EMU) && !defined(UFEMU)
 		"\a-t|\ax  \ay/boxr RaidAssistNum <1, 2, 3>\ax - Toggles which Raid MA to assist\n"
 #endif
@@ -71,6 +73,10 @@ void BoxrCommand(SPAWNINFO* pChar, char* szLine) {
 		MasterBoxControl::getInstance().Manual();
 	} else if (iStrEquals("burnnow", argVector.front())) {
 		MasterBoxControl::getInstance().BurnNow();
+	} else if (iStrEquals("burnoff", argVector.front())) {
+		MasterBoxControl::getInstance().BurnOff();
+	} else if (iStrEquals("burnnamed", argVector.front())) {
+		MasterBoxControl::getInstance().BurnNamed();
 	} else if (iStrEquals("raidassistnum", argVector.front())) {
 		if (argVector.size() != 2) {
 			LOGGER.error("/boxr RaidAssistNum: expected exactly one argument, but got {}", argVector.size() - 1);

--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ The mapping to CWTN commands is very straight-forward
 | `Chase`              | `/war mode chase`
 | `Manual`             | `/war mode manual`
 | `BurnNow`            | `/war BurnNow`
-| `BurnOff`            | `/war BurnNow`
-| `BurnNamed`          | `/war BurnNow`
+| `BurnOff`            | `/war BurnAlways off` <br/> `/war BurnAllNamed off`
+| `BurnNamed`          | `/war BurnAllNamed on`
 | `RaidAssistNum <N>`  | `/war RaidAssistNum <N>`
 
 #### KissAssist (`kissassist`)

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ The mapping to CWTN commands is very straight-forward
 | `Chase`              | `/rgl chaseon`
 | `Manual`             | `/rgl chaseoff`<br/>`/rgl campoff`
 | `BurnNow`            | `/rgl set BurnAlways 1`
-| `BurnOff`            | `/rgl set BurnAlways 1` <br/>`/rgl set BurnAuto off`
+| `BurnOff`            | `/rgl set BurnAlways 0` <br/>`/rgl set BurnAuto off`
 | `BurnNamed`          | `/rgl set BurnAuto on`
 | `RaidAssistNum <N>`  | *Not supported*
 

--- a/README.md
+++ b/README.md
@@ -94,9 +94,9 @@ The mapping to CWTN commands is very straight-forward
 | `Chase`              | `/rgl chaseon`
 | `Manual`             | `/rgl chaseoff`<br/>`/rgl campoff`
 | `BurnNow`            | `/rgl set BurnAlways 1`
-| `BurnOff`            | `/rgl set BurnAlways 0` <br/>`/rgl set BurnAuto off`
-| `BurnNamed`          | `/rgl set BurnAuto on`
-| `RaidAssistNum <N>`  | *Not supported*
+| `BurnOff`            | `/rgl set BurnAlways 0` <br/>`/rgl set BurnAuto 0`<br/>`/rgl set BurnNamed 0`
+| `BurnNamed`          | `/rgl set BurnNamed 1`
+| `RaidAssistNum <N>`  | `/rgl set RaidAssistTarget <N>`
 
 #### Entropy (`entropy`)
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ running.
 | `/boxr Chase`                   | Chase the MA, and assist in battle
 | `/boxr Manual`                  | Do not chase, do not return to camp. This state behaves a little bit different between different boxes, see [specifics](#specifics) below
 | `/boxr BurnNow`                 | Burn current target
+| `/boxr BurnOff`                 | Turns Burn Function Off
+| `/boxr BurnNAmed`               | Turns on Burn Functions for Named
 | `/boxr RaidAssistNum <1\|2\|3>` | Toggles which Raid MA the character will assist. This command is not supported on the Emulator build
 | `/boxr Debug <on\|off>`         | Turn on/off MQ2Boxr debug logging
 | `/boxr Help`                    | Print help text
@@ -38,6 +40,8 @@ The mapping to CWTN commands is very straight-forward
 | `Chase`              | `/war mode chase`
 | `Manual`             | `/war mode manual`
 | `BurnNow`            | `/war BurnNow`
+| `BurnOff`            | `/war BurnNow`
+| `BurnNamed`          | `/war BurnNow`
 | `RaidAssistNum <N>`  | `/war RaidAssistNum <N>`
 
 #### KissAssist (`kissassist`)
@@ -48,6 +52,8 @@ The mapping to CWTN commands is very straight-forward
 | `Chase`              | `/chaseon`
 | `Manual`             | `/chaseoff` <br/> `/camphere off`
 | `BurnNow`            | `/burn on doburn`
+| `BurnOff`            | `/burn off`
+| `BurnNamed`          | `/burn on`
 | `RaidAssistNum <N>`  | `/switchma <Name of Raid MA #N> tank 1`
 
 #### MuleAssist (`muleassist`)
@@ -88,6 +94,8 @@ The mapping to CWTN commands is very straight-forward
 | `Chase`              | `/rgl chaseon`
 | `Manual`             | `/rgl chaseoff`<br/>`/rgl campoff`
 | `BurnNow`            | `/rgl set BurnAlways 1`
+| `BurnOff`            | `/rgl set BurnAlways 1` <br/>`/rgl set BurnAuto off`
+| `BurnNamed`          | `/rgl set BurnAuto on`
 | `RaidAssistNum <N>`  | *Not supported*
 
 #### Entropy (`entropy`)
@@ -98,6 +106,8 @@ The mapping to CWTN commands is very straight-forward
 | `Chase`              | `/tie on`
 | `Manual`             | `/env auto off`
 | `BurnNow`            | `/burn force on`<br/>Will burn until force burn is toggled off again.
+| `BurnOff`            | `/burn force off` <br/>`/burn auto off`
+| `BurnNamed`          | `/burn auto on`
 | `RaidAssistNum <N>`  | `/cc ass smart <N>`
 
 #### XGen (`xgen`)
@@ -108,6 +118,8 @@ The mapping to CWTN commands is very straight-forward
 | `Chase`              | `/cc follow` <br/>`/cc camp off`
 | `Manual`             | `/cc manual`
 | `BurnNow`            | `/cc burnonce`
+| `BurnOff`            | `/cc burn off`
+| `BurnNamed`          | `/cc burn on`
 | `RaidAssistNum <N>`  | `/cc setassist <N>`
 
 ### TLO

--- a/boxr.cpp
+++ b/boxr.cpp
@@ -187,21 +187,24 @@ void RGMercsLuaControl::Manual() {
 void RGMercsLuaControl::BurnNow() {
 	boxrRunCommandf("/rgl set BurnAuto 1");
 	boxrRunCommandf("/rgl set BurnAlways 1");
+	LOGGER.info("Burns Always is now on.");
 }
 
 void RGMercsLuaControl::BurnOff() {
-	boxrRunCommandf("/rgl set BurnAlways 0");
 	boxrRunCommandf("/rgl set BurnAuto 0");
+	boxrRunCommandf("/rgl set BurnAlways 0");
 	boxrRunCommandf("/rgl set BurnNamed 0");
+	LOGGER.info("Burns are now off.");
 }
 
 void RGMercsLuaControl::BurnNamed() {
 	boxrRunCommandf("/rgl set BurnAuto 1");
 	boxrRunCommandf("/rgl set BurnNamed 1");
+	LOGGER.info("Burns for Named are now on.");
 }
 
 void RGMercsLuaControl::SetRaidAssistNum(int raidAssistNum) {
-	boxrRunCommandf("/rgl set RaidAssistTarget raidAssistNum);
+	boxrRunCommandf("/rgl set RaidAssistTarget {}", raidAssistNum);
 }
 
 bool KissAssistControl::IsRunning() {
@@ -232,14 +235,17 @@ void KissAssistControl::Manual() {
 
 void KissAssistControl::BurnNow() {
 	boxrRunCommandf("/burn on doburn");
+	LOGGER.info("Will burn current mob and turn burns on always.");
 }
 
 void KissAssistControl::BurnOff() {
 	boxrRunCommandf("/burn off");
+	LOGGER.info("Burns are now off.");
 }
 
 void KissAssistControl::BurnNamed() {
 	boxrRunCommandf("/burn on");
+	LOGGER.info("Burns for Named are now on.");
 }
 
 void KissAssistControl::SetRaidAssistNum(int raidAssistNum) {
@@ -293,14 +299,17 @@ void CwtnControl::Manual() {
 
 void CwtnControl::BurnNow() {
 	boxrRunCommandf("/{} BurnNow", GetClassCommand());
+	LOGGER.info("Will burn current mob.");
 }
 
 void CwtnControl::BurnOff() {
 	boxrRunCommandf("/{} BurnAlways off", GetClassCommand());
 	boxrRunCommandf("/{} BurnAllNamed off", GetClassCommand());
+	LOGGER.info("Burns are turned off.");
 }
 void CwtnControl::BurnNamed() {
 	boxrRunCommandf("/{} BurnAllNamed on", GetClassCommand());
+	LOGGER.info("Burn for Named is turned on.");
 }
 void CwtnControl::SetRaidAssistNum(int raidAssistNum) {
 	boxrRunCommandf("/{} raidassistnum {}", GetClassCommand(), raidAssistNum);
@@ -333,7 +342,7 @@ void EntropyControl::Manual() {
 
 void EntropyControl::BurnNow() {
 	boxrRunCommandf("/burn force on");
-	LOGGER.info("Will burn all the time. Use \ay/burn force off\ax to stop burning.");
+	LOGGER.info("Will burn all the time.");
 }
 
 void EntropyControl::BurnOff() {

--- a/boxr.cpp
+++ b/boxr.cpp
@@ -191,14 +191,15 @@ void RGMercsLuaControl::BurnNow() {
 void RGMercsLuaControl::BurnOff() {
 	boxrRunCommandf("/rgl set BurnAlways 0");
 	boxrRunCommandf("/rgl set BurnAuto 0");
+	boxrRunCommandf("/rgl set BurnNamed 0");
 }
 
 void RGMercsLuaControl::BurnNamed() {
-	boxrRunCommandf("/rgl set BurnAuto 1");
+	boxrRunCommandf("/rgl set BurnNamed 1");
 }
 
 void RGMercsLuaControl::SetRaidAssistNum(int raidAssistNum) {
-	LOGGER.info("RaidAssistNum is not supported for RGMercs - Lua edition");
+	boxrRunCommandf("/rgl set RaidAssistTarget raidAssistNum);
 }
 
 bool KissAssistControl::IsRunning() {

--- a/boxr.cpp
+++ b/boxr.cpp
@@ -185,6 +185,7 @@ void RGMercsLuaControl::Manual() {
 }
 
 void RGMercsLuaControl::BurnNow() {
+	boxrRunCommandf("/rgl set BurnAuto 1");
 	boxrRunCommandf("/rgl set BurnAlways 1");
 }
 
@@ -195,6 +196,7 @@ void RGMercsLuaControl::BurnOff() {
 }
 
 void RGMercsLuaControl::BurnNamed() {
+	boxrRunCommandf("/rgl set BurnAuto 1");
 	boxrRunCommandf("/rgl set BurnNamed 1");
 }
 

--- a/boxr.cpp
+++ b/boxr.cpp
@@ -53,6 +53,15 @@ void MasterBoxControl::BurnNow() {
 	GetBox()->BurnNow();
 }
 
+void MasterBoxControl::BurnOff() {
+	LOGGER.info("Burns are turned OFF!");
+	GetBox()->BurnOff();
+}
+
+void MasterBoxControl::BurnNamed() {
+	LOGGER.info("Burning NAMED!");
+	GetBox()->BurnNamed();
+}
 void MasterBoxControl::RaidAssistNum(int raidAssistNum) {
 #if !defined(ROF2EMU) && !defined(UFEMU)
 	LOGGER.info("Setting \a-tRaidAssistNum\ax to \at{}\ax (\at{}\ax)", raidAssistNum, GetRaidMainAssistName(raidAssistNum));
@@ -136,6 +145,14 @@ void RGMercsControl::BurnNow() {
 	LOGGER.info("BurnNow is not supported for rgmercs");
 }
 
+void RGMercsControl::BurnOff() {
+	LOGGER.info("BurnOff is not supported for rgmercs");
+}
+
+void RGMercsControl::BurnNamed() {
+	LOGGER.info("BurnNamed is not supported for rgmercs");
+}
+
 void RGMercsControl::SetRaidAssistNum(int raidAssistNum) {
 	boxrRunCommandf("/rg AssistOutside 1");
 	boxrRunCommandf(MACRO_COMMAND_DELAY "/rg OutsideAssistList {}", GetRaidMainAssistName(raidAssistNum));
@@ -171,6 +188,15 @@ void RGMercsLuaControl::BurnNow() {
 	boxrRunCommandf("/rgl set BurnAlways 1");
 }
 
+void RGMercsLuaControl::BurnOff() {
+	boxrRunCommandf("/rgl set BurnAlways 0");
+	boxrRunCommandf("/rgl set BurnAuto 0");
+}
+
+void RGMercsLuaControl::BurnNamed() {
+	boxrRunCommandf("/rgl set BurnAuto 1");
+}
+
 void RGMercsLuaControl::SetRaidAssistNum(int raidAssistNum) {
 	LOGGER.info("RaidAssistNum is not supported for RGMercs - Lua edition");
 }
@@ -203,6 +229,14 @@ void KissAssistControl::Manual() {
 
 void KissAssistControl::BurnNow() {
 	boxrRunCommandf("/burn on doburn");
+}
+
+void KissAssistControl::BurnOff() {
+	boxrRunCommandf("/burn off");
+}
+
+void KissAssistControl::BurnNamed() {
+	boxrRunCommandf("/burn on");
 }
 
 void KissAssistControl::SetRaidAssistNum(int raidAssistNum) {
@@ -258,6 +292,13 @@ void CwtnControl::BurnNow() {
 	boxrRunCommandf("/{} BurnNow", GetClassCommand());
 }
 
+void CwtnControl::BurnOff() {
+	boxrRunCommandf("/{} BurnAlways off", GetClassCommand());
+	boxrRunCommandf("/{} BurnAllNamed off", GetClassCommand());
+}
+void CwtnControl::BurnNamed() {
+	boxrRunCommandf("/{} BurnAllNamed on", GetClassCommand());
+}
 void CwtnControl::SetRaidAssistNum(int raidAssistNum) {
 	boxrRunCommandf("/{} raidassistnum {}", GetClassCommand(), raidAssistNum);
 }
@@ -290,6 +331,17 @@ void EntropyControl::Manual() {
 void EntropyControl::BurnNow() {
 	boxrRunCommandf("/burn force on");
 	LOGGER.info("Will burn all the time. Use \ay/burn force off\ax to stop burning.");
+}
+
+void EntropyControl::BurnOff() {
+	boxrRunCommandf("/burn force off");
+	boxrRunCommandf(MACRO_COMMAND_DELAY "/burn auto off");
+	LOGGER.info("All Burns turned off");
+}
+
+void EntropyControl::BurnNamed() {
+	boxrRunCommandf("/burn auto on");
+	LOGGER.info("Burn NAMED is on");
 }
 
 void EntropyControl::SetRaidAssistNum(int raidAssistNum) {
@@ -325,6 +377,16 @@ void XGenControl::Manual() {
 void XGenControl::BurnNow() {
 	boxrRunCommandf("/cc burnonce");
 	LOGGER.info("Will burn current mob only.");
+}
+
+void XGenControl::BurnOff() {
+	boxrRunCommandf("/cc burn off");
+	LOGGER.info("Burns turned off");
+}
+
+void XGenControl::BurnNamed() {
+	boxrRunCommandf("/cc burn on");
+	LOGGER.info("Burns are turned on.");
 }
 
 void XGenControl::SetRaidAssistNum(int raidAssistNum) {

--- a/boxr.h
+++ b/boxr.h
@@ -36,6 +36,8 @@ public:
 	virtual void Camp() = 0;
 	virtual void Manual() = 0;
 	virtual void BurnNow() = 0;
+	virtual void BurnOff() = 0;
+	virtual void BurnNamed() = 0;
 	virtual void SetRaidAssistNum(int raidAssistNum) = 0;
 
 	virtual std::string GetPauseQuery() = 0;
@@ -54,6 +56,8 @@ public:
 	void Camp() override;
 	void Manual() override;
 	void BurnNow() override;
+	void BurnOff() override;
+	void BurnNamed() override;
 	void SetRaidAssistNum(int raidAssistNum) override;
 	inline std::string GetPauseQuery() { return MACRO_PAUSED_QUERY; }
 };
@@ -69,6 +73,8 @@ public:
 	void Camp() override;
 	void Manual() override;
 	void BurnNow() override;
+	void BurnOff() override;
+	void BurnNamed() override;
 	void SetRaidAssistNum(int raidAssistNum) override;
 	inline std::string GetPauseQuery() { return MACRO_PAUSED_QUERY; }
 };
@@ -84,6 +90,8 @@ public:
 	void Camp() override;
 	void Manual() override;
 	void BurnNow() override;
+	void BurnOff() override;
+	void BurnNamed() override;
 	void SetRaidAssistNum(int raidAssistNum) override;
 	inline std::string GetPauseQuery() { return MACRO_PAUSED_QUERY; }
 };
@@ -116,6 +124,8 @@ public:
 	void Camp() override;
 	void Manual() override;
 	void BurnNow() override;
+	void BurnOff() override;
+	void BurnNamed() override;
 	void SetRaidAssistNum(int raidAssistNum) override;
 	inline std::string GetPauseQuery() { return "${CWTN.Paused}"; }
 
@@ -136,6 +146,8 @@ public:
 	void Camp() override;
 	void Manual() override;
 	void BurnNow() override;
+	void BurnOff() override;
+	void BurnNamed() override;
 	void SetRaidAssistNum(int raidAssistNum) override;
 	inline std::string GetPauseQuery() { return MACRO_PAUSED_QUERY; }
 };
@@ -151,6 +163,8 @@ public:
 	void Camp() override;
 	void Manual() override;
 	void BurnNow() override;
+	void BurnOff() override;
+	void BurnNamed() override;
 	void SetRaidAssistNum(int raidAssistNum) override;
 	inline std::string GetPauseQuery() { return MACRO_PAUSED_QUERY; }
 };
@@ -169,6 +183,8 @@ public:
 	void Camp() override { LOG_NOOP_WARNING; }
 	void Manual() override { LOG_NOOP_WARNING; }
 	void BurnNow() override { LOG_NOOP_WARNING; }
+	void BurnOff() override { LOG_NOOP_WARNING; }
+	void BurnNamed() override { LOG_NOOP_WARNING; }
 	void SetRaidAssistNum(int raidAssistNum) override { LOG_NOOP_WARNING; }
 	inline std::string GetPauseQuery() { THROW_NOOP_EXCEPTION; }
 };
@@ -189,6 +205,8 @@ public:
 	void Camp();
 	void Manual();
 	void BurnNow();
+	void BurnOff();
+	void BurnNamed();
 	void RaidAssistNum(int raidAssistNum);
 	bool IsPaused();
 	std::string Current();


### PR DESCRIPTION
I have updated RGMercs Lua to add the functionality of switching Raid Assists (/rgl set RaidAssist Target <N>).  I have changed the burn named to updated RGMerc lua command (/rgl set BurnNamed 1).

I have added function to turn burns off for RGMercs Lua, CWTN, KissAssist and XGen.